### PR TITLE
Add text-to-speech functionality with speak buttons

### DIFF
--- a/apps/dialogue/assets/styling/dialogue.css
+++ b/apps/dialogue/assets/styling/dialogue.css
@@ -375,3 +375,62 @@
     color: #94a3b8;
     font-size: 0.8rem;
 }
+
+/* Utterance content layout */
+.utterance-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.utterance-content .utterance-text {
+    flex: 1;
+}
+
+/* Speak button */
+.speak-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: 1px solid #2d3348;
+    border-radius: 6px;
+    background: #1e222d;
+    color: #94a3b8;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    flex-shrink: 0;
+    padding: 0;
+    line-height: 1;
+}
+
+.speak-btn:hover {
+    background: #252a38;
+    border-color: #6d85c6;
+    color: #e2e8f0;
+}
+
+.speak-btn:active {
+    background: #2d3348;
+    transform: scale(0.95);
+}
+
+.speak-btn-small {
+    width: 24px;
+    height: 24px;
+    font-size: 0.7rem;
+    border-radius: 4px;
+}
+
+/* Speak button in analysis original */
+.analysis-original .speak-btn {
+    margin-left: 8px;
+    vertical-align: middle;
+}
+
+/* Speak button in token chip */
+.token-chip .speak-btn-small {
+    margin-top: 4px;
+}

--- a/apps/dialogue/src/components/mod.rs
+++ b/apps/dialogue/src/components/mod.rs
@@ -1,2 +1,4 @@
 mod sentence_analysis;
+mod speak_button;
 pub use sentence_analysis::SentenceAnalysis;
+pub use speak_button::SpeakButton;

--- a/apps/dialogue/src/components/sentence_analysis.rs
+++ b/apps/dialogue/src/components/sentence_analysis.rs
@@ -1,3 +1,4 @@
+use crate::components::SpeakButton;
 use crate::server_fns::analyze_sentence;
 use dioxus::prelude::*;
 use kumou_japanese::{pos_css_class, pos_english};
@@ -18,6 +19,7 @@ pub fn SentenceAnalysis(text: String) -> Element {
                     div { class: "analysis-original",
                         span { class: "label", "Original: " }
                         "{result.text}"
+                        SpeakButton { text: result.text.clone() }
                     }
 
                     div { class: "token-flow",
@@ -27,6 +29,7 @@ pub fn SentenceAnalysis(text: String) -> Element {
                                 div { class: "token-surface", "{token.surface}" }
                                 div { class: "token-reading", "{token.reading}" }
                                 div { class: "token-pos", "{pos_english(&token.pos.major)}" }
+                                SpeakButton { text: token.surface.clone(), small: true }
                             }
                         }
                     }
@@ -42,6 +45,7 @@ pub fn SentenceAnalysis(text: String) -> Element {
                                     th { "POS" }
                                     th { "POS Detail" }
                                     th { "Conjugation" }
+                                    th { "" }
                                 }
                             }
                             tbody {
@@ -71,6 +75,9 @@ pub fn SentenceAnalysis(text: String) -> Element {
                                             if token.conjugation_form != "*" {
                                                 span { class: "conj-form", " ({token.conjugation_form})" }
                                             }
+                                        }
+                                        td {
+                                            SpeakButton { text: token.surface.clone(), small: true }
                                         }
                                     }
                                 }

--- a/apps/dialogue/src/components/speak_button.rs
+++ b/apps/dialogue/src/components/speak_button.rs
@@ -1,0 +1,53 @@
+use dioxus::prelude::*;
+
+/// Speaks the given text using the browser's Web Speech API with Japanese voice.
+/// Cancels any ongoing speech before starting.
+fn speak_japanese(text: &str) {
+    // Escape text for JavaScript string literal
+    let escaped = text
+        .replace('\\', "\\\\")
+        .replace('\'', "\\'")
+        .replace('\n', "\\n");
+
+    let js = format!(
+        r#"
+        (function() {{
+            const synth = window.speechSynthesis;
+            synth.cancel();
+            const utter = new SpeechSynthesisUtterance('{escaped}');
+            utter.lang = 'ja-JP';
+            utter.rate = 0.9;
+            // Try to find a Japanese voice
+            const voices = synth.getVoices();
+            const jaVoice = voices.find(v => v.lang.startsWith('ja'));
+            if (jaVoice) {{
+                utter.voice = jaVoice;
+            }}
+            synth.speak(utter);
+        }})();
+        "#
+    );
+
+    document::eval(&js);
+}
+
+#[component]
+pub fn SpeakButton(text: String, #[props(default = false)] small: bool) -> Element {
+    let class = if small {
+        "speak-btn speak-btn-small"
+    } else {
+        "speak-btn"
+    };
+
+    rsx! {
+        button {
+            class: class,
+            title: "Speak",
+            onclick: move |evt: Event<MouseData>| {
+                evt.stop_propagation();
+                speak_japanese(&text);
+            },
+            "\u{1f50a}"
+        }
+    }
+}

--- a/apps/dialogue/src/views/dialogue_detail.rs
+++ b/apps/dialogue/src/views/dialogue_detail.rs
@@ -1,5 +1,5 @@
 use crate::Route;
-use crate::components::SentenceAnalysis;
+use crate::components::{SentenceAnalysis, SpeakButton};
 use crate::server_fns::get_dialogue;
 use dioxus::prelude::*;
 use kumou_japanese::topic_name_ja;
@@ -38,20 +38,23 @@ pub fn DialogueDetail(dialogue_id: u32) -> Element {
                                     div { class: "speaker-label speaker-{utterance.speaker}",
                                         "Speaker {utterance.speaker}"
                                     }
-                                    p {
-                                        class: "utterance-text",
-                                        onclick: {
-                                            let text = utterance.utterance.clone();
-                                            move |_| {
-                                                let current = selected_sentence();
-                                                if current.as_deref() == Some(text.as_str()) {
-                                                    selected_sentence.set(None);
-                                                } else {
-                                                    selected_sentence.set(Some(text.clone()));
+                                    div { class: "utterance-content",
+                                        p {
+                                            class: "utterance-text",
+                                            onclick: {
+                                                let text = utterance.utterance.clone();
+                                                move |_| {
+                                                    let current = selected_sentence();
+                                                    if current.as_deref() == Some(text.as_str()) {
+                                                        selected_sentence.set(None);
+                                                    } else {
+                                                        selected_sentence.set(Some(text.clone()));
+                                                    }
                                                 }
-                                            }
-                                        },
-                                        "{utterance.utterance}"
+                                            },
+                                            "{utterance.utterance}"
+                                        }
+                                        SpeakButton { text: utterance.utterance.clone() }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
This PR adds text-to-speech (TTS) capabilities to the dialogue application, allowing users to hear Japanese text pronounced using the browser's Web Speech API. Speak buttons are now available throughout the interface for utterances, sentence analysis, and individual tokens.

## Key Changes
- **New `SpeakButton` component** (`speak_button.rs`): A reusable button component that triggers Japanese text-to-speech using the Web Speech API with language set to `ja-JP` and speech rate of 0.9x
- **Styling for speak buttons** (`dialogue.css`): Added comprehensive styles for speak buttons including normal, hover, and active states, with support for both regular and small variants
- **Integration in dialogue detail view**: Added speak buttons next to utterance text in the main dialogue display with a new `.utterance-content` flex layout
- **Integration in sentence analysis**: Added speak buttons for:
  - The original analyzed sentence
  - Individual tokens in the token flow display
  - Tokens in the analysis table
- **Updated component exports**: Added `SpeakButton` to the components module

## Implementation Details
- The speak button uses a speaker emoji (🔊) as the visual indicator
- Text is properly escaped for JavaScript string literals to handle special characters safely
- The Web Speech API automatically searches for a Japanese voice and falls back gracefully if unavailable
- Any ongoing speech is cancelled before starting new speech to prevent overlapping audio
- Small variant buttons (24px) are used in token displays, while full-size buttons (32px) are used for utterances
- The implementation uses Dioxus's `document::eval()` for JavaScript execution

https://claude.ai/code/session_01KDW9v3jq4dbrvyk8Gpb77R