### PR TITLE
feat(dialogue): use full Japanese Daily Dialogue dataset with pagination and search

### DIFF
--- a/apps/dialogue/assets/styling/dialogue.css
+++ b/apps/dialogue/assets/styling/dialogue.css
@@ -141,6 +141,125 @@
     margin: 4px 0;
 }
 
+/* Search bar */
+.search-bar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 20px;
+    align-items: center;
+}
+
+.search-input {
+    flex: 1;
+    background: #1e222d;
+    border: 1px solid #2d3348;
+    border-radius: 8px;
+    padding: 10px 16px;
+    color: #e2e8f0;
+    font-size: 0.95rem;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.search-input::placeholder {
+    color: #64748b;
+}
+
+.search-input:focus {
+    border-color: #6d85c6;
+}
+
+.search-btn {
+    background: #6d85c6;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 10px 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+    white-space: nowrap;
+}
+
+.search-btn:hover {
+    background: #5a72b3;
+}
+
+.search-clear-btn {
+    background: transparent;
+    color: #94a3b8;
+    border: 1px solid #2d3348;
+    border-radius: 8px;
+    padding: 10px 16px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+}
+
+.search-clear-btn:hover {
+    color: #e2e8f0;
+    border-color: #64748b;
+}
+
+.no-results {
+    color: #94a3b8;
+    text-align: center;
+    padding: 40px;
+    font-size: 1rem;
+}
+
+/* Pagination */
+.pagination {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+    margin-top: 24px;
+    flex-wrap: wrap;
+}
+
+.page-btn {
+    background: #1e222d;
+    color: #94a3b8;
+    border: 1px solid #2d3348;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    min-width: 36px;
+    text-align: center;
+}
+
+.page-btn:hover:not(:disabled) {
+    background: #252a38;
+    border-color: #6d85c6;
+    color: #e2e8f0;
+}
+
+.page-btn:disabled {
+    opacity: 0.35;
+    cursor: default;
+}
+
+.page-btn-active {
+    background: #6d85c6;
+    color: #fff;
+    border-color: #6d85c6;
+}
+
+.page-btn-active:hover {
+    background: #5a72b3;
+}
+
+.page-info {
+    text-align: center;
+    color: #64748b;
+    font-size: 0.85rem;
+    margin-top: 8px;
+}
+
 /* Conversation view */
 .dialogue-conversation {
     display: flex;

--- a/apps/dialogue/src/server_fns.rs
+++ b/apps/dialogue/src/server_fns.rs
@@ -1,12 +1,25 @@
 use dioxus::prelude::*;
-use kumou_japanese::{AnalyzedSentence, Dialogue, TopicSummary};
+use kumou_japanese::{AnalyzedSentence, Dialogue, DialoguePage, TopicSummary};
 
-const DIALOGUES_JSON: &str = include_str!("../data/dialogues.json");
+const TOPIC1_JSON: &str = include_str!("../assets/data/japanese-daily-dialogue/topic1.json");
+const TOPIC2_JSON: &str = include_str!("../assets/data/japanese-daily-dialogue/topic2.json");
+const TOPIC3_JSON: &str = include_str!("../assets/data/japanese-daily-dialogue/topic3.json");
+const TOPIC4_JSON: &str = include_str!("../assets/data/japanese-daily-dialogue/topic4.json");
+const TOPIC5_JSON: &str = include_str!("../assets/data/japanese-daily-dialogue/topic5.json");
+
+fn load_all_dialogues() -> Result<Vec<Dialogue>, ServerFnError> {
+    let mut all = Vec::new();
+    for json in [TOPIC1_JSON, TOPIC2_JSON, TOPIC3_JSON, TOPIC4_JSON, TOPIC5_JSON] {
+        let dialogues: Vec<Dialogue> =
+            kumou_japanese::load_dialogues(json).map_err(|e| ServerFnError::new(e.to_string()))?;
+        all.extend(dialogues);
+    }
+    Ok(all)
+}
 
 #[post("/api/topics")]
 pub async fn get_topics() -> Result<Vec<TopicSummary>> {
-    let dialogues: Vec<Dialogue> = kumou_japanese::load_dialogues(DIALOGUES_JSON)
-        .map_err(|e| ServerFnError::new(e.to_string()))?;
+    let dialogues = load_all_dialogues()?;
 
     let mut topics: Vec<TopicSummary> = Vec::new();
     for d in &dialogues {
@@ -25,21 +38,53 @@ pub async fn get_topics() -> Result<Vec<TopicSummary>> {
 }
 
 #[post("/api/dialogues_by_topic")]
-pub async fn get_dialogues_by_topic(topic_id: u32) -> Result<Vec<Dialogue>> {
-    let dialogues: Vec<Dialogue> = kumou_japanese::load_dialogues(DIALOGUES_JSON)
-        .map_err(|e| ServerFnError::new(e.to_string()))?;
+pub async fn get_dialogues_by_topic(
+    topic_id: u32,
+    page: usize,
+    per_page: usize,
+    search: String,
+) -> Result<DialoguePage> {
+    let dialogues = load_all_dialogues()?;
+
+    let per_page = if per_page == 0 { 20 } else { per_page.min(100) };
 
     let filtered: Vec<Dialogue> = dialogues
         .into_iter()
         .filter(|d| d.topic_id == topic_id)
+        .filter(|d| {
+            if search.is_empty() {
+                true
+            } else {
+                d.utterances
+                    .iter()
+                    .any(|u| u.utterance.contains(&search))
+            }
+        })
         .collect();
-    Ok(filtered)
+
+    let total = filtered.len();
+    let total_pages = (total + per_page - 1) / per_page;
+    let page = page.min(total_pages.saturating_sub(1));
+
+    let start = page * per_page;
+    let page_dialogues: Vec<Dialogue> = filtered
+        .into_iter()
+        .skip(start)
+        .take(per_page)
+        .collect();
+
+    Ok(DialoguePage {
+        dialogues: page_dialogues,
+        total,
+        page,
+        per_page,
+        total_pages,
+    })
 }
 
 #[post("/api/dialogue")]
 pub async fn get_dialogue(dialogue_id: u32) -> Result<Dialogue> {
-    let dialogues: Vec<Dialogue> = kumou_japanese::load_dialogues(DIALOGUES_JSON)
-        .map_err(|e| ServerFnError::new(e.to_string()))?;
+    let dialogues = load_all_dialogues()?;
 
     Ok(dialogues
         .into_iter()

--- a/apps/dialogue/src/views/topic_dialogues.rs
+++ b/apps/dialogue/src/views/topic_dialogues.rs
@@ -7,7 +7,16 @@ const DIALOGUE_CSS: Asset = asset!("/assets/styling/dialogue.css");
 
 #[component]
 pub fn TopicDialogues(topic_id: u32) -> Element {
-    let dialogues = use_server_future(move || get_dialogues_by_topic(topic_id))?;
+    let mut current_page = use_signal(|| 0usize);
+    let mut search_input = use_signal(|| String::new());
+    let mut active_search = use_signal(|| String::new());
+    let per_page = 20usize;
+
+    let dialogues = use_server_future(move || {
+        let search = active_search();
+        let page = current_page();
+        async move { get_dialogues_by_topic(topic_id, page, per_page, search).await }
+    })?;
 
     rsx! {
         document::Link { rel: "stylesheet", href: DIALOGUE_CSS }
@@ -16,16 +25,61 @@ pub fn TopicDialogues(topic_id: u32) -> Element {
             Link { to: Route::TopicList {}, class: "back-link", "← Back to Topics" }
 
             match &*dialogues.read() {
-                Some(Ok(dialogues)) => {
-                    let topic_name = dialogues.first().map(|d| d.topic_name.as_str()).unwrap_or("Unknown");
+                Some(Ok(page_data)) => {
+                    let topic_name = page_data.dialogues.first()
+                        .map(|d| d.topic_name.as_str())
+                        .unwrap_or("Unknown");
+                    let total = page_data.total;
+                    let total_pages = page_data.total_pages;
+                    let current = page_data.page;
                     rsx! {
                         h1 { class: "page-title",
                             "{topic_name_ja(topic_name)} "
                             span { class: "title-en", "({topic_name})" }
                         }
+                        p { class: "page-subtitle", "{total} dialogues" }
 
+                        // Search bar
+                        div { class: "search-bar",
+                            input {
+                                r#type: "text",
+                                class: "search-input",
+                                placeholder: "Search dialogues by Japanese text...",
+                                value: "{search_input}",
+                                oninput: move |e| {
+                                    search_input.set(e.value());
+                                },
+                                onkeydown: move |e| {
+                                    if e.key() == Key::Enter {
+                                        active_search.set(search_input());
+                                        current_page.set(0);
+                                    }
+                                },
+                            }
+                            button {
+                                class: "search-btn",
+                                onclick: move |_| {
+                                    active_search.set(search_input());
+                                    current_page.set(0);
+                                },
+                                "Search"
+                            }
+                            if !active_search().is_empty() {
+                                button {
+                                    class: "search-clear-btn",
+                                    onclick: move |_| {
+                                        search_input.set(String::new());
+                                        active_search.set(String::new());
+                                        current_page.set(0);
+                                    },
+                                    "Clear"
+                                }
+                            }
+                        }
+
+                        // Dialogue list
                         div { class: "dialogue-list",
-                            for dialogue in dialogues {
+                            for dialogue in &page_data.dialogues {
                                 Link {
                                     to: Route::DialogueDetail { dialogue_id: dialogue.dialogue_id },
                                     class: "dialogue-card",
@@ -47,10 +101,85 @@ pub fn TopicDialogues(topic_id: u32) -> Element {
                                 }
                             }
                         }
+
+                        if page_data.dialogues.is_empty() {
+                            p { class: "no-results", "No dialogues found matching your search." }
+                        }
+
+                        // Pagination
+                        if total_pages > 1 {
+                            div { class: "pagination",
+                                button {
+                                    class: "page-btn",
+                                    disabled: current == 0,
+                                    onclick: move |_| {
+                                        current_page.set(0);
+                                    },
+                                    "«"
+                                }
+                                button {
+                                    class: "page-btn",
+                                    disabled: current == 0,
+                                    onclick: move |_| {
+                                        current_page.set(current_page().saturating_sub(1));
+                                    },
+                                    "‹"
+                                }
+
+                                {render_page_numbers(current, total_pages, current_page)}
+
+                                button {
+                                    class: "page-btn",
+                                    disabled: current + 1 >= total_pages,
+                                    onclick: move |_| {
+                                        current_page.set(current_page() + 1);
+                                    },
+                                    "›"
+                                }
+                                button {
+                                    class: "page-btn",
+                                    disabled: current + 1 >= total_pages,
+                                    onclick: move |_| {
+                                        current_page.set(total_pages - 1);
+                                    },
+                                    "»"
+                                }
+                            }
+                            p { class: "page-info",
+                                "Page {current + 1} of {total_pages}"
+                            }
+                        }
                     }
                 },
                 Some(Err(e)) => rsx! { p { class: "error", "Error: {e}" } },
                 None => rsx! { p { class: "loading", "Loading dialogues..." } },
+            }
+        }
+    }
+}
+
+fn render_page_numbers(
+    current: usize,
+    total_pages: usize,
+    mut current_page: Signal<usize>,
+) -> Element {
+    // Show up to 7 page buttons around current page
+    let start = current.saturating_sub(3);
+    let end = (start + 7).min(total_pages);
+    let start = if end.saturating_sub(7) < start {
+        end.saturating_sub(7)
+    } else {
+        start
+    };
+
+    rsx! {
+        for p in start..end {
+            button {
+                class: if p == current { "page-btn page-btn-active" } else { "page-btn" },
+                onclick: move |_| {
+                    current_page.set(p);
+                },
+                "{p + 1}"
             }
         }
     }

--- a/crates/kumou-japanese/src/dialogue.rs
+++ b/crates/kumou-japanese/src/dialogue.rs
@@ -26,6 +26,16 @@ pub struct TopicSummary {
     pub dialogue_count: usize,
 }
 
+/// A paginated response of dialogues
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DialoguePage {
+    pub dialogues: Vec<Dialogue>,
+    pub total: usize,
+    pub page: usize,
+    pub per_page: usize,
+    pub total_pages: usize,
+}
+
 /// Load dialogues from a JSON string
 pub fn load_dialogues(json: &str) -> Result<Vec<Dialogue>, serde_json::Error> {
     serde_json::from_str(json)


### PR DESCRIPTION
Switch from the small sample dialogues.json (14 dialogues) to the full
dataset (~5,256 dialogues across 5 topics) loaded from the git submodule.
Add server-side pagination (20 per page) and Japanese text search to
handle the large dataset. Add search bar, pagination controls, and
corresponding CSS styles to the dialogue browser GUI.

https://claude.ai/code/session_011A4eGsEmrZsBraMoiCfn2e